### PR TITLE
Cutandpaste

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1025,28 +1025,59 @@ if (typeof Slick === "undefined") {
       absoluteColumnMinWidth = Math.max(headerColumnWidthDiff, cellWidthDiff);
     }
 
-    function createCssRules() {
-      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
-      var rowHeight = (options.rowHeight - cellHeightDiff);
-      var rules = [
-        "." + uid + " .slick-header-column { left: 1000px; }",
-        "." + uid + " .slick-top-panel { height:" + options.topPanelHeight + "px; }",
-        "." + uid + " .slick-headerrow-columns { height:" + options.headerRowHeight + "px; }",
-        "." + uid + " .slick-cell { height:" + rowHeight + "px; }",
-        "." + uid + " .slick-row { height:" + options.rowHeight + "px; }"
-      ];
+//    function createCssRules() {
+//      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
+//      var rowHeight = (options.rowHeight - cellHeightDiff);
+//      var rules = [
+//        "." + uid + " .slick-header-column { left: 1000px; }",
+//        "." + uid + " .slick-top-panel { height:" + options.topPanelHeight + "px; }",
+//        "." + uid + " .slick-headerrow-columns { height:" + options.headerRowHeight + "px; }",
+//        "." + uid + " .slick-cell { height:" + rowHeight + "px; }",
+//        "." + uid + " .slick-row { height:" + options.rowHeight + "px; }"
+//      ];
+//
+//      for (var i = 0; i < columns.length; i++) {
+//        rules.push("." + uid + " .l" + i + " { }");
+//        rules.push("." + uid + " .r" + i + " { }");
+//      }
+//
+//      if ($style[0].styleSheet) { // IE
+//        $style[0].styleSheet.cssText = rules.join(" ");
+//      } else {
+//        $style[0].appendChild(document.createTextNode(rules.join(" ")));
+//      }
+//    }
 
-      for (var i = 0; i < columns.length; i++) {
-        rules.push("." + uid + " .l" + i + " { }");
-        rules.push("." + uid + " .r" + i + " { }");
+      function createCssRules() {
+          $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
+          var rowHeight = (options.rowHeight - cellHeightDiff);
+          if ($style[0].styleSheet) { // IE
+              $style[0].styleSheet.cssText = "";
+          } else {
+              $style[0].appendChild(document.createTextNode(""));
+          }
+          var sheet =  $style[0].sheet;
+          var index = 0;
+          addCSSRule(sheet,"." + uid + " .slick-header-column", "left: 1000px;",index++);
+          addCSSRule(sheet,"." + uid + " .slick-top-panel", "height:" + options.topPanelHeight + "px;",index++);
+          addCSSRule(sheet,"." + uid + " .slick-headerrow-columns", "height:" + options.headerRowHeight + "px;",index++);
+          addCSSRule(sheet,"." + uid + " .slick-cell", "height:" + rowHeight + "px;",index++);
+          addCSSRule(sheet,"." + uid + " .slick-row", "height:" + options.rowHeight + "px;",index++);
+
+          for (var i = 0; i < columns.length; i++) {
+              addCSSRule(sheet,"." + uid + " .l" + i , "",index++);
+              addCSSRule(sheet,"." + uid + " .r" + i, "",index++);
+          }
       }
 
-      if ($style[0].styleSheet) { // IE
-        $style[0].styleSheet.cssText = rules.join(" ");
-      } else {
-        $style[0].appendChild(document.createTextNode(rules.join(" ")));
+      function addCSSRule(sheet, selector, rules, index) {
+          if(sheet.insertRule) {
+              sheet.insertRule(selector + "{" + rules + "}", index);
+          }
+          else {
+              sheet.addRule(selector, rules, index);
+          }
       }
-    }
 
     function getColumnCssRules(idx) {
       if (!stylesheet) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1597,9 +1597,9 @@ if (typeof Slick === "undefined") {
       if (!cacheEntry) {
         return;
       }
-      $canvas[0].removeChild(cacheEntry.rowNode);
+      $(cacheEntry.rowNode).remove();
       if (cacheEntry.lockedRowNode){
-        $lockedCanvas[0].removeChild(cacheEntry.lockedRowNode);
+        $(cacheEntry.lockedRowNode).remove();
       }
       delete rowsCache[row];
       delete postProcessedRows[row];
@@ -1862,11 +1862,11 @@ if (typeof Slick === "undefined") {
       while ((cellToRemove = cellsToRemove.pop()) != null) {
         var cellNode=cacheEntry.cellNodesByColumnIdx[cellToRemove];
         try {
-          cacheEntry.rowNode.removeChild(cellNode);
+          $(cellNode).remove();
         } catch (e){}
         try {
           if (cacheEntry.lockedRowNode){
-            cacheEntry.lockedRowNode.removeChild(cellNode);
+            $(cellNode).remove();
           }
         } catch (e){}
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1834,7 +1834,7 @@ if (typeof Slick === "undefined") {
       if (cacheEntry) {
         if (cacheEntry.cellRenderQueue.length) {
           var lastChild = cacheEntry.rowNode.lastChild;
-          while (cacheEntry.cellRenderQueue.length) {
+          while (lastChild && cacheEntry.cellRenderQueue.length) {
             var columnIdx = cacheEntry.cellRenderQueue.pop();
             cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
             lastChild = lastChild.previousSibling;


### PR DESCRIPTION
Hi Lawrence!    I hope you are doing better and will cherish the day you get back around to responding to this.   I miss you.   

So, I expect this change is probably going to get some push back from you or the upstream author because it will mean a slower removal of cell and row elements from the DOM.   But, since there is other jQuery stuff done in slickgrid and jQuery has no way of cleaning up things like .data() and aggregate events attached to the element when it is removed using the native DOM manipulation...  this is the only safe to tear down DOM and not leak memory.   This issue came to surface when I attached a bootstrap popover to a cell on post render.  (because it stores it's instance in a .data() element attached to the el)

I've switched the Zulily build to pull from this fork for the time being.

Hope to see you well soon;  sending you positive thoughts and energy.

~b
